### PR TITLE
Fix FileNotFoundError

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -55,7 +55,7 @@ def handle_react():
         os.symlink(src, dst)
 
     # Copy cookiecutter config for template to project dir
-    shutil.copyfile(os.path.expanduser('~/.cookiecutter_replay/django-template.json'), '.cookiecutterrc')
+    shutil.copyfile(os.path.expanduser('~/.cookiecutter_replay/django-project-template.json'), '.cookiecutterrc')
 
 
 def create_repos():


### PR DESCRIPTION
Hi,

a path in post gen hook code was wrong:

```
FileNotFoundError: [Errno 2] No such file or directory: '/Users/username/.cookiecutter_replay/django-template.json'
ERROR: Stopping generation because post_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```